### PR TITLE
Added the duplicate button functionality

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -184,8 +184,7 @@ span.sortable-ghost {
   padding: 0.5em;
   color: var(--color-light);
   background-color: var(--color-button);
-  border: 0.2em solid var(--color-light);
-  outline: 0.2em solid var(--color-button);
+  border: none;
   cursor: pointer;
   transition: background-color 0.2s ease, outline-color 0.2s ease;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -139,7 +139,7 @@ span.sortable-ghost {
   display: none;
 }
 
-#properties input[type='text'] {
+#colors input[type='text'] {
   width: 100%;
   max-width: 20em;
   margin: 0 0.2em;
@@ -147,7 +147,7 @@ span.sortable-ghost {
   color: var(--color-dark);
 }
 
-#properties button {
+#colors button {
   min-width: 10em;
   margin: 0 0.2em 0.6em;
   padding: 0.5em;
@@ -159,8 +159,8 @@ span.sortable-ghost {
   transition: background-color 0.2s ease, outline-color 0.2s ease;
 }
 
-#properties button:hover,
-#properties button:focus {
+#colors button:hover,
+#colors button:focus {
   background-color: var(--color-button-alt);
   outline-color: var(--color-button-alt);
 }
@@ -177,6 +177,23 @@ span.sortable-ghost {
   margin-right: 0.4em;
   color: var(--color-accent);
   vertical-align: middle;
+}
+
+#controls button{
+  margin: 0.4em 0;
+  padding: 0.5em;
+  color: var(--color-light);
+  background-color: var(--color-button);
+  border: 0.2em solid var(--color-light);
+  outline: 0.2em solid var(--color-button);
+  cursor: pointer;
+  transition: background-color 0.2s ease, outline-color 0.2s ease;
+}
+
+#controls button:hover,
+#controls button:focus {
+  background-color: var(--color-button-alt);
+  outline-color: var(--color-button-alt);
 }
 
 #flex4 > p.hint {

--- a/index.html
+++ b/index.html
@@ -77,8 +77,10 @@
       <div id="properties">
         <input type="text" id="properties-data" autocomplete="off">
         <h3>Colors</h3>
-        <button type="button" id="properties-fg-color">Foreground Color</button>
-        <button type="button" id="properties-bg-color">Background Color</button>
+        <div id="colors">
+          <button type="button" id="properties-fg-color">Foreground Color</button>
+          <button type="button" id="properties-bg-color">Background Color</button>
+        </div>
         <h3>Display Attributes</h3>
         <label><input type="checkbox" name="properties-bold" id="properties-bold">Bold</label>
         <label><input type="checkbox" name="properties-dim" id="properties-dim">Dim</label>
@@ -87,6 +89,10 @@
         <label><input type="checkbox" name="properties-blink" id="properties-blink">Blink</label>
         <label><input type="checkbox" name="properties-reverse" id="properties-reverse">Reverse</label>
         <label><input type="checkbox" name="properties-overline" id="properties-overline">Overline</label>
+        <h3>Commands</h3>
+        <div id="controls">
+          <button type="button" id="properties-duplicate">Duplicate</button>
+        </div>
       </div>
     </div>
     <div id="flex4">

--- a/js/index.js
+++ b/js/index.js
@@ -94,50 +94,26 @@ function selectElementAndShowProperties(element) {
 }
 
 function duplicateElement(element){
-  // Make a copy of the element 
-  const copiedElement = element.clone();
-  
-  // Remove the class element-selected
-  copiedElement.removeClass('element-selected');
- 
-  // Insert to added-elements-container 
-  $('#added-elements-container').append(copiedElement);
-  
-  // Get the index of the element
-  const index = $('.element-added').index(element);
-  
-  // Get the element prompt 
-  const elementPrompt = prompt.getElement(index);
-  
-  // Make a new Escaped Prompt Element using the copied data
-  const newElement = new EscapedPromptElement(
-      elementPrompt.content,
-      elementPrompt.fgColor,
-      elementPrompt.bgColor,
-      elementPrompt.data,
-  );
-
-  // Copy the display attribs to the new element
-  for(let i=0; i<elementPrompt.displayAttribs.length; i++){
-    newElement.displayAttribs.push(elementPrompt.displayAttribs[i])
+  // Make a copy of element properties
+  function cloneElement(element, newElement){
+    for (const prop in element) {
+      if (element.hasOwnProperty(prop)) {
+        newElement[prop] = element[prop];
+      }
+    }
   }
-  
-  // Add the element to the pormpt 
-  prompt.appendElement(newElement);
 
-  // Add the click event
-  copiedElement.click(() => {
-    selectElementAndShowProperties(copiedElement);
-  });
+  // Get the current prompt element
+  const index = $('.element-added').index(element);
+  const elementPrompt = prompt.getElement(index);
+  const key = element.attr('data-key');
 
-  // Add the delete event 
-  copiedElement.find('.remove-element').click(() => {
-    copiedElement.fadeOut(SHOW_HIDE_DURATION, () => copiedElement.remove());
-    prompt.removeElement(index);
-    prompt.updateCallback();
-  });
+  // Create and add the new element
+  const newElement = new EscapedPromptElement(PromptElement[key])
+  cloneElement(elementPrompt, newElement);    
+  addPromptElement(key);
+  prompt.appendElement(newElement);    
 }
-
 
 function addPromptElement(key) {
   const el = PromptElement[key];

--- a/js/index.js
+++ b/js/index.js
@@ -85,8 +85,59 @@ function selectElementAndShowProperties(element) {
     });
   });
 
+  $('#properties-duplicate').off('click').click(() => {
+    duplicateElement(element);
+    prompt.updateCallback();
+  }); 
+
   $('#properties').fadeIn(SHOW_HIDE_DURATION);
 }
+
+function duplicateElement(element){
+  // Make a copy of the element 
+  const copiedElement = element.clone();
+  
+  // Remove the class element-selected
+  copiedElement.removeClass('element-selected');
+ 
+  // Insert to added-elements-container 
+  $('#added-elements-container').append(copiedElement);
+  
+  // Get the index of the element
+  const index = $('.element-added').index(element);
+  
+  // Get the element prompt 
+  const elementPrompt = prompt.getElement(index);
+  
+  // Make a new Escaped Prompt Element using the copied data
+  const newElement = new EscapedPromptElement(
+      elementPrompt.content,
+      elementPrompt.fgColor,
+      elementPrompt.bgColor,
+      elementPrompt.data,
+  );
+
+  // Copy the display attribs to the new element
+  for(let i=0; i<elementPrompt.displayAttribs.length; i++){
+    newElement.displayAttribs.push(elementPrompt.displayAttribs[i])
+  }
+  
+  // Add the element to the pormpt 
+  prompt.appendElement(newElement);
+
+  // Add the click event
+  copiedElement.click(() => {
+    selectElementAndShowProperties(copiedElement);
+  });
+
+  // Add the delete event 
+  copiedElement.find('.remove-element').click(() => {
+    copiedElement.fadeOut(SHOW_HIDE_DURATION, () => copiedElement.remove());
+    prompt.removeElement(index);
+    prompt.updateCallback();
+  });
+}
+
 
 function addPromptElement(key) {
   const el = PromptElement[key];


### PR DESCRIPTION
Added a new section inside **Properties** with a new command called duplicate. This command will duplicate the current element and add a new element to the end of the prompt. I think this would be really useful to use instead of making an element manually and copying the properties from one to another. Note that I'm not professional in Jquery so please look at that 

This is how it looks like: 
![image](https://user-images.githubusercontent.com/63660298/153727071-47403bd0-ff09-4581-be26-8f145087fd8d.png)
