### PR TITLE
Git branch switches in real-time now

### DIFF
--- a/src/lib/enum/promptElementType.ts
+++ b/src/lib/enum/promptElementType.ts
@@ -171,7 +171,7 @@ export const PROMPT_ELEMENT_TYPES = [
   new PromptElementType(
     'Git branch',
     // eslint-disable-next-line quotes
-    "$(git branch 2>/dev/null | grep ' ^* ' | colrm 1 2)",
+    "$(git branch 2>/dev/null | grep '*' | colrm 1 2)",
     [],
     true,
     'Git branch.',


### PR DESCRIPTION
Earlier the previous git branch was apparent when doing a checkout, which meant the branch I switched "from" showed "after" doing the checkout. Corrected that.